### PR TITLE
change input and output types for the parse utility

### DIFF
--- a/utils/decode.ts
+++ b/utils/decode.ts
@@ -8,7 +8,7 @@ export class DecodeError {
   constructor(readonly error: string) {}
 }
 
-export function parseEither<A>(schema: Schema.Schema<A>) {
+export function parseEither<_, A>(schema: Schema.Schema<_, A>) {
   return (input: unknown) =>
     pipe(
       Schema.parseEither(schema)(input, { errors: "all" }),


### PR DESCRIPTION
In the current implementation, the input and output types are always the same, which leads to wrong behavior in case of transformations — adapting the types to match the actual parseEffect typing.